### PR TITLE
Feature/type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+**/__pycache__
+**/*.egg-info

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The library makes it very easy to support other frameworks besides numpy and pyt
 Note that most frameworks already support these functions. To now integrate the framework just inherit from the `pypatchify.patch.Patchify` class and enter the functions:
 
 ```python
-class NewFramework(Patchify):
+class NewFramework(Patchify[NewTensorType]):
     # get shape and strides from tensor object
     shape:Callable
     strides:Callable

--- a/pypatchify/__init__.py
+++ b/pypatchify/__init__.py
@@ -1,4 +1,5 @@
 from .np import np
+from numpy import ndarray
 
 try:
     import torch
@@ -9,9 +10,9 @@ except ImportError:
 if IS_TORCH_AVAILABLE:
     from .pt import pt
 
-from typing import Optional, Tuple
+from typing import Any, Optional, Sequence, Union
 
-def patchify(t, patch_sizes:Tuple[int]):
+def patchify(t:Union[ndarray, Any], patch_sizes:Sequence[int]) -> Union[ndarray, Any]:
     """ Patchify n-dimension tensor with given patch size 
 
         Args:
@@ -33,7 +34,7 @@ def patchify(t, patch_sizes:Tuple[int]):
     return np.patchify(t, patch_sizes)
 
     
-def unpatchify(t, unpatched_sizes:Tuple[int]):
+def unpatchify(t:Union[ndarray, Any], unpatched_sizes:Sequence[int]) -> Union[ndarray, Any]:
     """ Merge patches of given patched tensor
 
         Args:
@@ -56,7 +57,7 @@ def unpatchify(t, unpatched_sizes:Tuple[int]):
     # fallback to numpy
     return np.unpatchify(t, unpatched_sizes)
     
-def patchify_to_batches(t, patch_sizes:Tuple[int], batch_dim:Optional[int] =0):
+def patchify_to_batches(t:Union[ndarray, Any], patch_sizes:Sequence[int], batch_dim:Optional[int] =0) -> Union[ndarray, Any]:
     """ Patchify n-dimension tensor with given patch size and collapse patching
         dimensions into batch dimension.
     
@@ -81,7 +82,7 @@ def patchify_to_batches(t, patch_sizes:Tuple[int], batch_dim:Optional[int] =0):
     # fallback to numpy
     return np.patchify_to_batches(t, patch_sizes, batch_dim)
     
-def unpatchify_from_batches(t, unpatched_sizes:Tuple[int], batch_dim:Optional[int] =0):
+def unpatchify_from_batches(t:Union[ndarray, Any], unpatched_sizes:Sequence[int], batch_dim:Optional[int] =0) -> Union[ndarray, Any]:
     """ Merge patches of given patched tensor with patched collapsed
         into batch dimension
 

--- a/pypatchify/__init__.py
+++ b/pypatchify/__init__.py
@@ -105,3 +105,43 @@ def unpatchify_from_batches(t:Union[ndarray, Any], unpatched_sizes:Sequence[int]
         return pt.unpatchify_from_batches(t, unpatched_sizes, batch_dim)
     # fallback to numpy
     return np.unpatchify_from_batches(t, unpatched_sizes, batch_dim)
+
+def collapse_dims(cls, t:Union[ndarray, Any], dims:Sequence[int], target_dim:int =0) -> Union[ndarray, Any]:
+    """ Collapse multiple dimensions of a given tensor 
+
+        Args:
+            t (Tensor): input tensor
+            dims (Sequence[int]): dimensions to collapse in the input tensor
+            target_dim (int): dimension into which to collapse the given dimensions. Defaults to 0.
+    
+        Returns:
+            collapsed (Tensor): tensor with dimensions collapsed into target dimension
+    """
+    # use pytorch if given
+    if IS_TORCH_AVAILABLE and isinstance(t, torch.Tensor):
+        return pt.collapse_dims(t, dims, target_dim)
+    # fallback to numpy
+    return np.collapse_dims(t, dims, target_dim)
+
+def sliding_window(cls, t:Union[ndarray, Any], window_dims:Sequence[int], strides:Sequence[int]) -> Union[ndarray, Any]:
+    """ Sliding Window view on given tensor
+        
+        Args:
+            t (Tensor): 
+                tensor object of dimension k on which to apply the sliding window view
+            window_dims (Sequence[int]): 
+                dimensions of sliding window. Window dimensionality n must be <= k.
+                Windows will be applied to the last n dimensions of the input tensor.
+            strides (Sequence[int]): 
+                strides (i.e. step size) of sliding window in each dimension
+
+        Returns:
+            windows (Tensor): 
+                tensor containing sliding windows in shape (d_1, ..., d_(k-n), p_1, ..., p_n, *window_dims)
+                where pi is the number of sliding windows in the i-th dimension
+    """
+    # use pytorch if given
+    if IS_TORCH_AVAILABLE and isinstance(t, torch.Tensor):
+        return pt.sliding_window(t, window_dims, strides)
+    # fallback to numpy
+    return np.sliding_window(t, window_dims, strides)

--- a/pypatchify/np.py
+++ b/pypatchify/np.py
@@ -1,7 +1,7 @@
 import numpy
 from .patch import Patchify
 
-class np(Patchify):
+class np(Patchify[numpy.ndarray]):
     """ Collection of patchification functionality for numpy arrays """
     # get shape and strides from tensor object
     shape = lambda t: t.shape

--- a/pypatchify/patch.py
+++ b/pypatchify/patch.py
@@ -1,7 +1,9 @@
-from typing import Optional, Sequence, Callable
+from typing import Optional, Sequence, Callable, Generic, TypeVar
 from itertools import chain
 
-class Patchify(object):
+T = TypeVar('T')
+
+class Patchify(Generic[T]):
 
     # get shape and strides from tensor object
     shape:Callable
@@ -12,7 +14,7 @@ class Patchify(object):
     as_strided:Callable
 
     @classmethod
-    def sliding_window(cls, t, window_dims:Sequence[int], strides:Sequence[int]):
+    def sliding_window(cls, t, window_dims:Sequence[int], strides:Sequence[int]) -> T:
         """ Sliding Window view on given tensor
             
             Args:
@@ -44,7 +46,7 @@ class Patchify(object):
         return cls.as_strided(t, tuple(shape), tuple(strides))
 
     @classmethod
-    def patchify(cls, t, patch_sizes:Sequence[int]):
+    def patchify(cls, t, patch_sizes:Sequence[int]) -> T:
         """ Patchify n-dimension tensor with given patch size 
 
             Args:
@@ -62,7 +64,7 @@ class Patchify(object):
         return cls.sliding_window(t, patch_sizes, patch_sizes)
 
     @classmethod
-    def unpatchify(cls, t, unpatched_sizes:Sequence[int]):
+    def unpatchify(cls, t, unpatched_sizes:Sequence[int]) -> T:
         """ Merge patches of given patched tensor
 
             Args:
@@ -90,7 +92,7 @@ class Patchify(object):
         return cls.reshape(t, tuple(merged_shape))
 
     @classmethod
-    def collapse_dims(cls, t, dims:Sequence[int], target_dim:int =0):
+    def collapse_dims(cls, t, dims:Sequence[int], target_dim:int =0) -> T:
         """ Collapse multiple dimensions of a given tensor 
 
             Args:
@@ -119,7 +121,7 @@ class Patchify(object):
         return cls.reshape(t, shape)
 
     @classmethod
-    def patchify_to_batches(cls, t, patch_sizes:Sequence[int], batch_dim:Optional[int] =0):
+    def patchify_to_batches(cls, t, patch_sizes:Sequence[int], batch_dim:Optional[int] =0) -> T:
         """ Patchify n-dimension tensor with given patch size and collapse patching
             dimensions into batch dimension.
         
@@ -149,7 +151,7 @@ class Patchify(object):
         )
 
     @classmethod
-    def unpatchify_from_batches(cls, t, unpatched_sizes:Sequence[int], batch_dim:Optional[int] =0):
+    def unpatchify_from_batches(cls, t, unpatched_sizes:Sequence[int], batch_dim:Optional[int] =0) -> T:
         """ Merge patches of given patched tensor with patched collapsed
             into batch dimension
 

--- a/pypatchify/pt.py
+++ b/pypatchify/pt.py
@@ -1,7 +1,7 @@
 import torch
 from .patch import Patchify
 
-class pt(Patchify):
+class pt(Patchify[torch.Tensor]):
     """ Collection of patchification functionality for torch tensors """
     # get shape and strides from tensor object
     shape = torch.Tensor.size

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="pypatchify",
-    version="0.1.3",
+    version="0.1.4",
     description="Fast and easy image and n-dimensional volume patchification",
     long_description=open("README.md", "r").read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
* [Generic Type Hinting.](https://github.com/ndoll1998/patchify/commit/9e90e42933c1f828f8050771981d286ebebfbba3)
  * `Patchify` class is now generic typed. Subclasses can express array type by setting the `T` TypeVar.
  * (added .gitignore)
* [NDArray Typehints in init. (Numpy is imported anyway)](https://github.com/ndoll1998/patchify/commit/12621b1ada3a319b42c61ea5d6906301f57e63fe)
  * Because `pypatchify.np` if imported by default we can at least give type hints for numpy arrays (Better than nothing)
* [Additional Functions in init (Nice to have)](https://github.com/ndoll1998/patchify/commit/4bee16dc49de9531be4b9b336348018f1252c485)
  * There are some Use-cases for this